### PR TITLE
Fix nimble storage volume stats reporting

### DIFF
--- a/cinder/tests/test_nimble.py
+++ b/cinder/tests/test_nimble.py
@@ -326,14 +326,15 @@ class NimbleDriverVolumeTestCase(NimbleDriverBaseTestCase):
     def test_get_volume_stats(self):
         self.mock_client_service.service.getGroupConfig.return_value = \
             FAKE_POSITIVE_GROUP_CONFIG_RESPONSE
-        expected_res = {'driver_version': '1.0',
-                        'total_capacity_gb': 7466.30419921875,
-                        'QoS_support': False,
-                        'reserved_percentage': 0,
+        expected_res = {'driver_version': '1.0.1',
                         'vendor_name': 'Nimble',
                         'volume_backend_name': 'NIMBLE',
                         'storage_protocol': 'iSCSI',
-                        'free_capacity_gb': 7463.567649364471}
+                        'pools': [{'pool_name': 'NIMBLE',
+                                   'total_capacity_gb': 7466.30419921875,
+                                   'free_capacity_gb': 7463.567649364471,
+                                   'reserved_percentage': 0,
+                                   'QoS_support': False}]}
         self.assertEqual(
             expected_res,
             self.driver.get_volume_stats(refresh=True))

--- a/cinder/volume/drivers/nimble.py
+++ b/cinder/volume/drivers/nimble.py
@@ -34,7 +34,7 @@ from cinder.openstack.common import units
 from cinder.volume.drivers.san.san import SanISCSIDriver
 
 
-DRIVER_VERSION = '1.0'
+DRIVER_VERSION = '1.0.1'
 VOL_EDIT_MASK = 4 + 16 + 32 + 64 + 512
 SOAP_PORT = 5391
 SM_ACL_APPLY_TO_BOTH = 3
@@ -73,7 +73,7 @@ class NimbleISCSIDriver(SanISCSIDriver):
 
     Version history:
         1.0 - Initial driver
-
+        1.0.1 - Correct capacity reporting
     """
 
     def __init__(self, *args, **kwargs):
@@ -264,11 +264,16 @@ class NimbleISCSIDriver(SanISCSIDriver):
             self.group_stats = {'volume_backend_name': backend_name,
                                 'vendor_name': 'Nimble',
                                 'driver_version': DRIVER_VERSION,
-                                'storage_protocol': 'iSCSI',
-                                'total_capacity_gb': total_capacity,
-                                'free_capacity_gb': free_space,
-                                'reserved_percentage': 0,
-                                'QoS_support': False}
+                                'storage_protocol': 'iSCSI'}
+            # Just use a single pool for now, FIXME to support multiple
+            # pools
+            single_pool = dict(
+                pool_name=backend_name,
+                total_capacity_gb=total_capacity,
+                free_capacity_gb=free_space,
+                reserved_percentage=0,
+                QoS_support=False)
+            self.group_stats['pools'] = [single_pool]
         return self.group_stats
 
     def extend_volume(self, volume, new_size):


### PR DESCRIPTION
Capacity now needs to be reported in a pool, to support pool-aware
scheduling which was introduced in the Juno development cycle.

Change-Id: I1a3ea2c75bc0296868e281a3fbfb6636ab0f0e3e
(cherry picked from commit 0648992430a98a6c987979b64ae02c36a79572d8)
