### PR TITLE
Update pbr reqs to avoid a build issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-pbr!=0.7,<1.0,>=0.6
+pbr<2.0,>=1.4
 anyjson<=0.3.3,>=0.3.3
 argparse
 Babel<=1.3,>=1.3


### PR DESCRIPTION
Not sure why this is breaking in our build env, but something was
dragging in pbr 0.11.0 which was not acceptable.

Change-Id: I35bbcfeacac65ef65a65914addc03cd64a4037cf
