### PR TITLE
Backport nimble driver fixes to juno

### DIFF
--- a/cinder/tests/test_nimble.py
+++ b/cinder/tests/test_nimble.py
@@ -215,7 +215,9 @@ class NimbleDriverVolumeTestCase(NimbleDriverBaseTestCase):
             'provider_location': '172.18.108.21:3260 iqn.test 0',
             'provider_auth': None},
             self.driver.create_volume({'name': 'testvolume',
-                                       'size': 1}))
+                                       'size': 1,
+                                       'display_name': '',
+                                       'display_description': ''}))
         self.mock_client_service.service.createVol.assert_called_once_with(
             request={
                 'attr': {'snap-quota': 1073741824, 'warn-level': 858993459,
@@ -236,7 +238,9 @@ class NimbleDriverVolumeTestCase(NimbleDriverBaseTestCase):
             exception.VolumeBackendAPIException,
             self.driver.create_volume,
             {'name': 'testvolume',
-             'size': 1})
+             'size': 1,
+             'display_name': '',
+             'display_description': ''})
 
     @mock.patch(NIMBLE_URLLIB2)
     @mock.patch(NIMBLE_CLIENT)
@@ -353,7 +357,9 @@ class NimbleDriverSnapshotTestCase(NimbleDriverBaseTestCase):
             FAKE_GENERIC_POSITIVE_RESPONSE
         self.driver.create_snapshot(
             {'volume_name': 'testvolume',
-             'name': 'testvolume-snap1'})
+             'name': 'testvolume-snap1',
+             'display_name': '',
+             'display_description': ''})
         self.mock_client_service.service.snapVol.assert_called_once_with(
             request={'vol': 'testvolume',
                      'snapAttr': {'name': 'testvolume-snap1',

--- a/cinder/tests/test_nimble.py
+++ b/cinder/tests/test_nimble.py
@@ -330,15 +330,14 @@ class NimbleDriverVolumeTestCase(NimbleDriverBaseTestCase):
     def test_get_volume_stats(self):
         self.mock_client_service.service.getGroupConfig.return_value = \
             FAKE_POSITIVE_GROUP_CONFIG_RESPONSE
-        expected_res = {'driver_version': '1.0.1',
+        expected_res = {'driver_version': '1.0',
+                        'total_capacity_gb': 7466.30419921875,
+                        'QoS_support': False,
+                        'reserved_percentage': 0,
                         'vendor_name': 'Nimble',
                         'volume_backend_name': 'NIMBLE',
                         'storage_protocol': 'iSCSI',
-                        'pools': [{'pool_name': 'NIMBLE',
-                                   'total_capacity_gb': 7466.30419921875,
-                                   'free_capacity_gb': 7463.567649364471,
-                                   'reserved_percentage': 0,
-                                   'QoS_support': False}]}
+                        'free_capacity_gb': 7463.567649364471}
         self.assertEqual(
             expected_res,
             self.driver.get_volume_stats(refresh=True))

--- a/cinder/volume/drivers/nimble.py
+++ b/cinder/volume/drivers/nimble.py
@@ -21,6 +21,7 @@ This driver supports Nimble Storage controller CS-Series.
 import functools
 import random
 import re
+import six
 import string
 import urllib2
 
@@ -392,9 +393,10 @@ def _connection_checker(func):
             try:
                 return func(self, *args, **kwargs)
             except NimbleAPIException as e:
-                if attempts < 1 and (re.search('SM-eaccess', str(e))):
+                if attempts < 1 and (re.search('SM-eaccess',
+                                     six.text_type(e))):
                     LOG.info(_('Session might have expired.'
-                               ' Trying to relogin'))
+                                 ' Trying to relogin'))
                     self.login()
                     continue
                 else:

--- a/cinder/volume/drivers/nimble.py
+++ b/cinder/volume/drivers/nimble.py
@@ -95,7 +95,7 @@ class NimbleISCSIDriver(SanISCSIDriver):
         subnet_label = self.configuration.nimble_subnet_label
         LOG.debug('subnet_label used %(netlabel)s, netconfig %(netconf)s'
                   % {'netlabel': subnet_label, 'netconf': netconfig})
-        ret_discovery_ip = None
+        ret_discovery_ip = ''
         for subnet in netconfig['subnet-list']:
             LOG.info(_('Exploring array subnet label %s') % subnet['label'])
             if subnet_label == '*':
@@ -207,7 +207,9 @@ class NimbleISCSIDriver(SanISCSIDriver):
                          self._generate_random_string(12))
         snapshot = {'volume_name': src_vref['name'],
                     'name': snapshot_name,
-                    'volume_size': src_vref['size']}
+                    'volume_size': src_vref['size'],
+                    'display_name': '',
+                    'display_description': ''}
         self.APIExecutor.snap_vol(snapshot)
         self._clone_volume_from_snapshot(volume, snapshot)
         return self._get_model_info(volume['name'])
@@ -313,7 +315,7 @@ class NimbleISCSIDriver(SanISCSIDriver):
                                 'iname': initiator_name})
                     return initiator_group['name']
         LOG.info(_('No igroup found for initiator %s') % initiator_name)
-        return None
+        return ''
 
     def initialize_connection(self, volume, connector):
         """Driver entry point to attach a volume to an instance."""
@@ -472,20 +474,21 @@ class NimbleAPIExecutor:
         # Set volume size, display name and description
         volume_size = volume['size'] * units.Gi
         reserve_size = volume_size if reserve else 0
-        display_name = (volume['display_name']
-                        if 'display_name' in volume else '')
-        display_description = (': ' + volume['display_description']
-                               if 'display_description' in volume else '')
-        description = display_name + display_description
+        # Set volume description
+        display_list = [getattr(volume, 'display_name', ''),
+                        getattr(volume, 'display_description', '')]
+        description = ':'.join(filter(None, display_list))
         # Limit description size to 254 characters
         description = description[:254]
 
         LOG.info(_('Creating a new volume=%(vol)s size=%(size)s'
-                   ' reserve=%(reserve)s in pool=%(pool)s')
+                     ' reserve=%(reserve)s in pool=%(pool)s'
+                     ' description=%(description)s')
                  % {'vol': volume['name'],
                     'size': volume_size,
                     'reserve': reserve,
-                    'pool': pool_name})
+                    'pool': pool_name,
+                    'description': description})
         return self.client.service.createVol(
             request={'sid': self.sid,
                      'attr': {'name': volume['name'],
@@ -605,13 +608,10 @@ class NimbleAPIExecutor:
         """Execute snapVol API."""
         volume_name = snapshot['volume_name']
         snap_name = snapshot['name']
-        # Set description
-        snap_display_name = (snapshot['display_name']
-                             if 'display_name' in snapshot else '')
-        snap_display_description = (
-            ': ' + snapshot['display_description']
-            if 'display_description' in snapshot else '')
-        snap_description = snap_display_name + snap_display_description
+        # Set snapshot description
+        display_list = [getattr(snapshot, 'display_name', ''),
+                        getattr(snapshot, 'display_description', '')]
+        snap_description = ':'.join(filter(None, display_list))
         # Limit to 254 characters
         snap_description = snap_description[:254]
         LOG.info(_('Creating snapshot for volume_name=%(vol)s'

--- a/cinder/volume/drivers/nimble.py
+++ b/cinder/volume/drivers/nimble.py
@@ -35,7 +35,7 @@ from cinder.openstack.common import units
 from cinder.volume.drivers.san.san import SanISCSIDriver
 
 
-DRIVER_VERSION = '1.0.1'
+DRIVER_VERSION = '1.0'
 VOL_EDIT_MASK = 4 + 16 + 32 + 64 + 512
 SOAP_PORT = 5391
 SM_ACL_APPLY_TO_BOTH = 3
@@ -74,7 +74,7 @@ class NimbleISCSIDriver(SanISCSIDriver):
 
     Version history:
         1.0 - Initial driver
-        1.0.1 - Correct capacity reporting
+
     """
 
     def __init__(self, *args, **kwargs):
@@ -267,16 +267,11 @@ class NimbleISCSIDriver(SanISCSIDriver):
             self.group_stats = {'volume_backend_name': backend_name,
                                 'vendor_name': 'Nimble',
                                 'driver_version': DRIVER_VERSION,
-                                'storage_protocol': 'iSCSI'}
-            # Just use a single pool for now, FIXME to support multiple
-            # pools
-            single_pool = dict(
-                pool_name=backend_name,
-                total_capacity_gb=total_capacity,
-                free_capacity_gb=free_space,
-                reserved_percentage=0,
-                QoS_support=False)
-            self.group_stats['pools'] = [single_pool]
+                                'storage_protocol': 'iSCSI',
+                                'total_capacity_gb': total_capacity,
+                                'free_capacity_gb': free_space,
+                                'reserved_percentage': 0,
+                                'QoS_support': False}
         return self.group_stats
 
     def extend_volume(self, volume, new_size):


### PR DESCRIPTION
These fix problems nimble driver would have when dealing with strings, particularly error strings that would mask the actual problem. This also fixes a case where a volume description is not provided.

Finally the change from master to report capacity in a pool is reverted as it is not actually needed.
